### PR TITLE
feat: 도커 CI/CD 파이프라인 설정 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.gradle
+build
+out
+**/*.iml
+.idea
+.env

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,29 @@
+name: CI/CD Pipeline
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Build Docker image
+        run: docker build -t reading-tracker .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM gradle:8.14.2-jdk21 AS build
+WORKDIR /app
+
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN chmod +x gradlew
+
+COPY src ./src
+RUN ./gradlew clean bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+ENV SPRING_PROFILES_ACTIVE=prod
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
- render로 배포 예정
- Render는 Spring 서비스를 그대로 올릴 수는 없어, Docker로 배포해야 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced CI workflow to automatically run tests and build a container image on pushes and pull requests to the main branch.
  * Added ignore patterns to reduce Docker build context and speed up image builds.
  * Implemented a multi-stage container build, producing a smaller Java 21 runtime image, configured for the production profile and exposing port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->