### PR TITLE
명령어에 파이프 추가

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -75,6 +75,6 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: reading-tracker-app
           IMAGE_TAG: latest
-        run:
+        run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
원인: 파이프가 없어서 두 명령어가 하나의 명령어로 합쳐져 실행되어 [에러 발생](https://github.com/yeslee-v/reading-tracker/actions/runs/19265821280/job/55081330333#step:6:1)

<img width="1336" height="428" alt="Screenshot 2025-11-11 at 21 47 26" src="https://github.com/user-attachments/assets/8d19c34e-8f38-402b-a81c-f93ecc6578ca" />
